### PR TITLE
implement api basic directory structure

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,0 +1,14 @@
+tools:
+	go get golang.org/x/tools/cmd/goimports
+
+fmt:
+	go fmt ./...
+
+imports:
+	goimports -w -l $(shell find . -name "*.go" | grep -v /vendor/)
+
+vet:
+	go vet ./...
+
+test:
+	go test -p 6 -race -cover ./...

--- a/api/domain/entity/entry.go
+++ b/api/domain/entity/entry.go
@@ -1,0 +1,7 @@
+package entity
+
+// Entry represents entry entity.
+type Entry struct {
+	Title string
+	URL   string
+}

--- a/api/infrastructure/router/router.go
+++ b/api/infrastructure/router/router.go
@@ -1,0 +1,21 @@
+package router
+
+import (
+	"net/http"
+
+	"github.com/Khigashiguchi/khigashiguchi.com/api/interfaces/handlers"
+	"github.com/gorilla/mux"
+)
+
+// New create http routing.
+func New() http.Handler {
+	r := mux.NewRouter()
+	// create api endpoint
+	r.Methods("GET").Path("/api/entries").HandlerFunc(handlers.GetEntriesHandler)
+
+	// create health check endpoint
+	r.Methods("GET").Path("/.health_check").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	return r
+}

--- a/api/interfaces/handlers/entry_handler.go
+++ b/api/interfaces/handlers/entry_handler.go
@@ -1,0 +1,20 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/Khigashiguchi/khigashiguchi.com/api/domain/entity"
+	"github.com/Khigashiguchi/khigashiguchi.com/api/interfaces/presenter"
+)
+
+// GetEntriesHandler handle request GET /entries.
+func GetEntriesHandler(w http.ResponseWriter, r *http.Request) {
+	// FIXME: テストを通すための仮実装
+	res := presenter.GetEntriesResponse{
+		Entities: entity.Entry{
+			Title: "test title",
+			URL:   "http://example.com",
+		},
+	}
+	presenter.RespondJson(w, res, http.StatusOK)
+}

--- a/api/interfaces/handlers/entry_handler_test.go
+++ b/api/interfaces/handlers/entry_handler_test.go
@@ -1,0 +1,58 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Khigashiguchi/khigashiguchi.com/api/domain/entity"
+	"github.com/Khigashiguchi/khigashiguchi.com/api/interfaces/handlers"
+	"github.com/Khigashiguchi/khigashiguchi.com/api/interfaces/presenter"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetEntriesHandler(t *testing.T) {
+	tests := []struct {
+		name         string
+		expectedCD   int
+		expectedBody presenter.GetEntriesResponse
+	}{
+		{
+			name:       "response_any_record",
+			expectedCD: http.StatusOK,
+			expectedBody: presenter.GetEntriesResponse{
+				Entities: entity.Entry{
+					Title: "test title",
+					URL:   "http://example.com",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/entries", nil)
+
+			handlers.GetEntriesHandler(w, r)
+
+			res := w.Result()
+			defer res.Body.Close()
+
+			if tt.expectedCD != res.StatusCode {
+				t.Errorf("expected: %#v, given #%v", tt.expectedCD, res.StatusCode)
+			}
+			if expected := "application/json; charset=utf-8"; expected != res.Header.Get("Content-Type") {
+				t.Errorf("expected: #%v, given #%v", expected, res.Header.Get("Content-Type"))
+			}
+			var body presenter.GetEntriesResponse
+			if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+				t.Errorf("unexpected error by json.Decode(): %#v", err)
+			}
+			if diff := cmp.Diff(tt.expectedBody, body); diff != "" {
+				t.Errorf("differs: (-want +got)\n%s", diff)
+			}
+		})
+	}
+}

--- a/api/interfaces/presenter/base.go
+++ b/api/interfaces/presenter/base.go
@@ -1,0 +1,18 @@
+package presenter
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+// RespondJson return the response.
+func RespondJson(w http.ResponseWriter, body interface{}, code int) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(code)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to encode response: %s", err)
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}

--- a/api/interfaces/presenter/base_test.go
+++ b/api/interfaces/presenter/base_test.go
@@ -1,0 +1,76 @@
+package presenter_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Khigashiguchi/khigashiguchi.com/api/interfaces/presenter"
+	"github.com/google/go-cmp/cmp"
+)
+
+type testResponse struct {
+	Field1 string `json:"field1"`
+	Field2 int    `json:"field2"`
+}
+
+func TestRespondJson(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         interface{}
+		cd           int
+		expectedCD   int
+		expectedBody string
+	}{
+		{
+			name: "respond_struct_status_200",
+			body: testResponse{
+				Field1: "test",
+				Field2: 1,
+			},
+			cd:           http.StatusOK,
+			expectedCD:   http.StatusOK,
+			expectedBody: "{\"field1\":\"test\",\"field2\":1}\n",
+		},
+		{
+			name:         "respond_empty_status_200",
+			body:         struct{}{},
+			cd:           http.StatusOK,
+			expectedCD:   http.StatusOK,
+			expectedBody: "{}\n",
+		},
+		{
+			name:         "respond_status_500",
+			body:         struct{}{},
+			cd:           http.StatusInternalServerError,
+			expectedCD:   http.StatusInternalServerError,
+			expectedBody: "{}\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			presenter.RespondJson(w, tt.body, tt.cd)
+
+			res := w.Result()
+			defer res.Body.Close()
+
+			if tt.expectedCD != res.StatusCode {
+				t.Errorf("expected: %#v, given #%v", tt.expectedCD, res.StatusCode)
+			}
+			if expected := "application/json; charset=utf-8"; expected != res.Header.Get("Content-Type") {
+				t.Errorf("expected: #%v, given #%v", expected, res.Header.Get("Content-Type"))
+			}
+			body, err := ioutil.ReadAll(res.Body)
+			if err != nil {
+				t.Errorf("unexpected error by ioutil.ReadAll(): %#v", err)
+			}
+			if diff := cmp.Diff(tt.expectedBody, string(body)); diff != "" {
+				t.Errorf("differs: (-want +got)\n%s", diff)
+			}
+		})
+	}
+}

--- a/api/interfaces/presenter/entry_presenter.go
+++ b/api/interfaces/presenter/entry_presenter.go
@@ -1,0 +1,8 @@
+package presenter
+
+import "github.com/Khigashiguchi/khigashiguchi.com/api/domain/entity"
+
+// GetEntriesResponse represents the format response.
+type GetEntriesResponse struct {
+	Entities entity.Entry `json:"entities"`
+}

--- a/api/main.go
+++ b/api/main.go
@@ -1,17 +1,20 @@
 package main
 
 import (
-	"net/http"
 	"fmt"
+	"net/http"
 	"os"
+
+	"github.com/Khigashiguchi/khigashiguchi.com/api/infrastructure/router"
 )
 
 // Run exec to start http server.
 func serve() {
+	r := router.New()
 	port := 8080
-	fmt.Fprintf(os.Stdout, "start to run http server at port %d", port)
-	if err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to start server: %s", err)
+	fmt.Fprintf(os.Stdout, "start to run http server at port %d\n", port)
+	if err := http.ListenAndServe(fmt.Sprintf(":%d", port), r); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start server: %s\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
```
-> % tree -L 3
.
├── LICENSE
├── README.md
└── api
    ├── Makefile
    ├── domain
    │   └── entity
    ├── infrastructure
    │   └── router
    ├── interfaces
    │   ├── handlers
    │   └── presenter
    ├── main.go
    └── usecase
        └── empty
```